### PR TITLE
make plotPFA work again

### DIFF
--- a/data/pfaT0/plot.py
+++ b/data/pfaT0/plot.py
@@ -83,7 +83,7 @@ if __name__ == "__main__":
 
 
         g.plot(
-            graph.data.points(data_eta7, x=1, y=3, title="numerisch vs Bordag"),
+            graph.data.points(data_eta7, x=1, y=3, title="numerisch"),
             [graph.style.symbol(graph.style.symbol.circle, size=0.04, symbolattrs=attrs)]
         )
 
@@ -91,7 +91,7 @@ if __name__ == "__main__":
         g.plot(graph.data.function(f, title="Bimonte et al."))
 
         g2.plot(
-            graph.data.points(data_eta7, x=1, y=3, title="numerisch vs Bordag"),
+            graph.data.points(data_eta7, x=1, y=3, title="numerisch"),
             [graph.style.symbol(graph.style.symbol.circle, size=0.04, symbolattrs=attrs)]
         )
 


### PR DESCRIPTION
With data for η=7 and 8, the PFA plot did not work anymore. It seems that in this plot, there is no significant visual difference between the two data sets, so I have replaced `data` by `data_eta7`. The rest of the changes is merely cosmetic, trying to avoid the use of `continue` and improving the titles.
