### PR TITLE
unnecessary import removed

### DIFF
--- a/data/pfa/finitetemp.py
+++ b/data/pfa/finitetemp.py
@@ -3,7 +3,6 @@ from math import pi, exp
 import numpy as np
 from scipy.integrate import quad
 from scipy.special import zetac
-from mpmath import polylog
 from pyx import *
 
 def extract_matsubara(line):


### PR DESCRIPTION
There was an unnecessary import of `mpmath` left over from the previous version of the integrand. This PR removes this import.
