### PR TITLE
some improvements to the docs

### DIFF
--- a/src/mainpage.dox
+++ b/src/mainpage.dox
@@ -46,7 +46,11 @@ a plane. The plane is infinite in the xy-direction.
 \subsection installation Installation
 
 If you use Linux or Unix, you need the gcc and development libraries and header
-files for the standard C library. On a Debian-like Linux the commands
+files for the standard C library. In addition, the hodlr_wrapper repository should
+be cloned from https://github.com/michael-hartmann/hodlr_wrapper in parallel to the
+present repository.
+
+On a Debian-like Linux the commands
 
     $ sudo apt-get install gcc libc6-dev make liblapack-dev libopenmpi-dev openmpi-bin
     $ cd src/


### PR DESCRIPTION
I started reading the docs. The most important point missing so far was the reference to `hodlr_wrapper`. Unfortunately, the compilation of `casimir_logdetD` fails in line 97, but this should probably be discussed elsewhere.