### PR TITLE
Fix contribution of xi=0 for plasma model

### DIFF
--- a/src/casimir.c
+++ b/src/casimir.c
@@ -551,7 +551,7 @@ void master(int argc, char *argv[], const int cores)
             else if(material == NULL && gamma_ == 0)
             {
                 printf("# model = plasma\n");
-                v[0] = casimir_logdetD0_plasma(casimir, omegap, cutoff);
+                v[0] = casimir_logdetD0_plasma(casimir, omegap*(L+R)/(CASIMIR_hbar_eV*CASIMIR_c), cutoff);
             }
             else if(material == NULL)
             {

--- a/src/integration.c
+++ b/src/integration.c
@@ -292,7 +292,7 @@ static double _casimir_integrate_K(integration_t *self, int nu, polarization_t p
     const double epsrel = self->epsrel;
 
     /* some analytical solutions for perfect reflectors */
-    #if 1
+    #if 0
     if(self->is_pr)
     {
         if(p == TE)
@@ -885,15 +885,15 @@ double casimir_integrate_D(integration_t *self, int l1, int l2, polarization_t p
     return casimir_integrate_C(self, l2, l1, p, sign);
 }
 
-integration_plasma_t *casimir_integrate_plasma_init(casimir_t *casimir, double omegap, double epsrel)
+integration_plasma_t *casimir_integrate_plasma_init(casimir_t *casimir, double omegap_, double epsrel)
 {
     integration_plasma_t *self;
 
     self = (integration_plasma_t *)xmalloc(sizeof(integration_plasma_t));
-    self->LbyR   = casimir->LbyR;
-    self->omegap = omegap;
-    self->alpha  = omegap/(1+casimir->LbyR);
-    self->epsrel = epsrel;
+    self->LbyR    = casimir->LbyR;
+    self->omegap_ = omegap_;
+    self->alpha   = omegap_/(1+casimir->LbyR);
+    self->epsrel  = epsrel;
 
     const int ldim = casimir->ldim;
     self->cache       = cache_new(3*ldim, 0.3);
@@ -955,7 +955,7 @@ double casimir_integrate_plasma(integration_plasma_t *self, int l1, int l2, int 
 
     /* perform integrations in intervals [0,a], [a,b] and [b,∞] */
     const double epsrel = self->epsrel;
-    integrand_plasma_t args = { .nu = nu, .omegap = self->omegap, .log_prefactor = -lfac(nu) };
+    integrand_plasma_t args = { .nu = nu, .omegap = self->omegap_, .log_prefactor = -lfac(nu) };
 
     int neval1 = 0, neval2 = 0, neval3 = 0, ier1 = 0, ier2 = 0, ier3 = 0;
     double abserr1 = 0, abserr2 = 0, abserr3 = 0, I1 = 0, I2 = 0, I3 = 0;

--- a/src/libcasimir.c
+++ b/src/libcasimir.c
@@ -983,11 +983,11 @@ double casimir_logdetD0_perf(casimir_t *casimir, double eps)
  * The abort criterion eps is the same as in \ref casimir_logdetD0_perf.
  *
  * @param [in] casimir Casimir object
- * @param [in] omegap plasma frequency \f$\omega_P\f$ in rad/s
+ * @param [in] omegap_ scaled plasma frequency, omegap*(L+R)/c
  * @param [in] eps abort criterion
  * @retval logdetD \f$\log\det\mathcal{D}(\xi=0)\f$ for plasma model
  */
-double casimir_logdetD0_plasma(casimir_t *casimir, double omegap, double eps)
+double casimir_logdetD0_plasma(casimir_t *casimir, double omegap_, double eps)
 {
     const double drude = casimir_logdetD0_drude(casimir);
     double MM_plasma = 0;
@@ -995,7 +995,7 @@ double casimir_logdetD0_plasma(casimir_t *casimir, double omegap, double eps)
     for(int m = 0; true; m++)
     {
         double v;
-        casimir_logdetD0(casimir, m, omegap, NULL, NULL, &v);
+        casimir_logdetD0(casimir, m, omegap_, NULL, NULL, &v);
 
         if(m == 0)
             MM_plasma += v/2;
@@ -1023,12 +1023,12 @@ double casimir_logdetD0_plasma(casimir_t *casimir, double omegap, double eps)
  *
  * @param [in]  self Casimir object
  * @param [in]  m quantum number \f$m\f$
- * @param [in]  omegap Plasma frequency \f$\omega_P\f$ in rad/s (only used to compute MM_plasma)
+ * @param [in]  omegap_ scaled plasma frequency, omegap*(L+R)/c (only used to compute MM_plasma)
  * @param [out] EE pointer to store contribution for EE block
  * @param [out] MM pointer to store contribution for MM block
  * @param [out] MM_plasma pointer to store contribution for MM block (Plasma model)
  */
-void casimir_logdetD0(casimir_t *self, int m, double omegap, double *EE, double *MM, double *MM_plasma)
+void casimir_logdetD0(casimir_t *self, int m, double omegap_, double *EE, double *MM, double *MM_plasma)
 {
     size_t lmin, lmax;
     const int is_symmetric = 1, ldim = self->ldim;
@@ -1055,7 +1055,7 @@ void casimir_logdetD0(casimir_t *self, int m, double omegap, double *EE, double 
 
     if(MM_plasma != NULL)
     {
-        args.integration_plasma = casimir_integrate_plasma_init(self, omegap, self->epsrel);
+        args.integration_plasma = casimir_integrate_plasma_init(self, omegap_, self->epsrel);
         *MM_plasma = kernel_logdet(ldim, &casimir_kernel_M0_MM_plasma, &args, is_symmetric, detalg);
         casimir_integrate_plasma_free(args.integration_plasma);
     }

--- a/src/libcasimir.h
+++ b/src/libcasimir.h
@@ -68,7 +68,7 @@ typedef struct {
 } integration_t;
 
 typedef struct {
-    double LbyR, alpha, omegap, epsrel;
+    double LbyR, alpha, omegap_, epsrel;
     cache_t *cache;
     cache_t *cache_ratio;
 } integration_plasma_t;
@@ -126,7 +126,7 @@ double casimir_epsilonm1_drude(double xi_, void *userdata);
 
 double casimir_logdetD0_drude(casimir_t *casimir);
 double casimir_logdetD0_perf(casimir_t *casimir, double eps);
-double casimir_logdetD0_plasma(casimir_t *casimir, double omegap, double eps);
+double casimir_logdetD0_plasma(casimir_t *casimir, double omegap_, double eps);
 
 double casimir_kernel_M0_EE(int i, int j, void *args);
 double casimir_kernel_M0_MM(int i, int j, void *args);


### PR DESCRIPTION
The contribution of the zero-th Matsubara frequency in the plasma model was
wrong. The program gave the wrong parameter to the function
casimir_logdetD0_plasma which expects the scaled plasma frequency
omegap*(L+R)/c instead of the plasma frequency.

This bug only occured when casimir was started with a value for omegap and
without a value for gamma.

No publication is affected by this bug.