### PR TITLE
Change mail address to caps@speicherleck.de

### DIFF
--- a/CREDITS
+++ b/CREDITS
@@ -2,7 +2,7 @@ This is a list of people that have contributed to CaPS. The fields are
 name (N), email (E) and description (D).
 
 N: Michael Hartmann
-E: <michael.hartmann@physik.uni-augsburg.de>
+E: <caps@speicherleck.de>
 D: Main developer.
 
 N: Gert-Ludwig Ingold

--- a/src/bessel.c
+++ b/src/bessel.c
@@ -1,7 +1,7 @@
 /**
  * @file   bessel.c
  * @author Stephen L. Moshier, Cephes Math Library Release 2.8, June 2000
- * @author Michael Hartmann <michael.hartmann@physik.uni-augsburg.de>
+ * @author Michael Hartmann <caps@speicherleck.de>
  * @date   October, 2019
  * @brief  Computation of Bessel functions
  */

--- a/src/cache.c
+++ b/src/cache.c
@@ -1,6 +1,6 @@
 /**
  * @file   cache.c
- * @author Michael Hartmann <michael.hartmann@physik.uni-augsburg.de>
+ * @author Michael Hartmann <caps@speicherleck.de>
  * @date   February, 2019
  * @brief  implementation of a simple cache using a hash table
  */

--- a/src/fcqs.c
+++ b/src/fcqs.c
@@ -1,6 +1,6 @@
 /**
  * @file   fcqs.c
- * @author Michael Hartmann <michael.hartmann@physik.uni-augsburg.de>
+ * @author Michael Hartmann <caps@speicherleck.de>
  * @date   December, 2018
  * @brief  exponentially convergent Fourier-Chebshev quadrature scheme (experimental)
  */

--- a/src/include/constants.h
+++ b/src/include/constants.h
@@ -1,6 +1,6 @@
 /**
  * @file   constants.h
- * @author Michael Hartmann <michael.hartmann@physik.uni-augsburg.de>
+ * @author Michael Hartmann <caps@speicherleck.de>
  * @date   December, 2018
  * @brief  define macros and constants
  */

--- a/src/include/libcaps.h
+++ b/src/include/libcaps.h
@@ -1,6 +1,6 @@
 /**
  * @file   libcaps.h
- * @author Michael Hartmann <michael.hartmann@physik.uni-augsburg.de>
+ * @author Michael Hartmann <caps@speicherleck.de>
  * @date   February, 2019
  */
 

--- a/src/include/utils.h
+++ b/src/include/utils.h
@@ -1,6 +1,6 @@
 /**
  * @file   utils.h
- * @author Michael Hartmann <michael.hartmann@physik.uni-augsburg.de>
+ * @author Michael Hartmann <caps@speicherleck.de>
  * @date   July, 2017
  * @brief  wrappers for malloc, calloc and realloc, assert-like macros, now()-function
  */

--- a/src/integration.c
+++ b/src/integration.c
@@ -1,6 +1,6 @@
 /**
  * @file   integration.c
- * @author Michael Hartmann <michael.hartmann@physik.uni-augsburg.de>
+ * @author Michael Hartmann <caps@speicherleck.de>
  * @date   December, 2018
  * @brief  Perform integration for arbitrary materials
  */

--- a/src/libcaps.c
+++ b/src/libcaps.c
@@ -1,6 +1,6 @@
 /**
  * @file   libcaps.c
- * @author Michael Hartmann <michael.hartmann@physik.uni-augsburg.de>
+ * @author Michael Hartmann <caps@speicherleck.de>
  * @date   December, 2017
  * @brief  library to calculate the free Casimir energy in the plane-sphere geometry
  */

--- a/src/logfac.c
+++ b/src/logfac.c
@@ -2,7 +2,7 @@
 
 /**
  * @file   logfac.c
- * @author Michael Hartmann <michael.hartmann@physik.uni-augsburg.de>
+ * @author Michael Hartmann <caps@speicherleck.de>
  * @date   January, 2019
  * @brief  computation of logarithm and factorial for integer arguments; created by logfac.py
  */

--- a/src/material.c
+++ b/src/material.c
@@ -1,6 +1,6 @@
 /**
  * @file   material.c
- * @author Michael Hartmann <michael.hartmann@physik.uni-augsburg.de>
+ * @author Michael Hartmann <caps@speicherleck.de>
  * @date   January, 2019
  * @brief  support for arbitrary dielectric functions
  */

--- a/src/matrix.c
+++ b/src/matrix.c
@@ -1,6 +1,6 @@
 /**
  * @file   matrix.c
- * @author Michael Hartmann <michael.hartmann@physik.uni-augsburg.de>
+ * @author Michael Hartmann <caps@speicherleck.de>
  * @date   January, 2019
  * @brief  Matrix functions
  */

--- a/src/misc.c
+++ b/src/misc.c
@@ -1,6 +1,6 @@
 /**
  * @file   misc.c
- * @author Michael Hartmann <michael.hartmann@physik.uni-augsburg.de>
+ * @author Michael Hartmann <caps@speicherleck.de>
  * @date   July, 2017
  * @brief  various mathematical functions
  */

--- a/src/plm.c
+++ b/src/plm.c
@@ -1,6 +1,6 @@
 /**
  * @file   plm.c
- * @author Michael Hartmann <michael.hartmann@physik.uni-augsburg.de>
+ * @author Michael Hartmann <caps@speicherleck.de>
  * @date   January, 2019
  * @brief  computation of Legendre and associated Legendre polynomials
  */

--- a/src/psd.c
+++ b/src/psd.c
@@ -1,6 +1,6 @@
 /**
  * @file   psd.c
- * @author Michael Hartmann <michael.hartmann@physik.uni-augsburg.de>
+ * @author Michael Hartmann <caps@speicherleck.de>
  * @date   December, 2018
  * @brief  expansion coefficients and poles for Pade spectrum decomposition
  */

--- a/src/python/logfac.py
+++ b/src/python/logfac.py
@@ -48,7 +48,7 @@ double lfac2(unsigned int n) __attribute__ ((pure));
 
 /**
  * @file   logfac.c
- * @author Michael Hartmann <michael.hartmann@physik.uni-augsburg.de>
+ * @author Michael Hartmann <caps@speicherleck.de>
  * @date   %s, %d
  * @brief  computation of logarithm and factorial for integer arguments; created by logfac.py
  */

--- a/src/utils.c
+++ b/src/utils.c
@@ -1,6 +1,6 @@
 /**
  * @file   utils.c
- * @author Michael Hartmann <michael.hartmann@physik.uni-augsburg.de>
+ * @author Michael Hartmann <caps@speicherleck.de>
  * @date   January, 2018
  * @brief  wrappers for malloc, calloc realloc, and a few more useful functions
  */


### PR DESCRIPTION
This PR cahnges the mail address of @michael-hartmann from `michael.hartmann@physik.uni-augsburg.de` to `caps@speicherleck.de`, see also issue #119.