### PR TITLE
Avoid crashes when compiling with MSVC

### DIFF
--- a/src/libhodlr/src/HODLR_Matrix.cpp
+++ b/src/libhodlr/src/HODLR_Matrix.cpp
@@ -148,7 +148,7 @@ void HODLR_Matrix::rookPiv(int n_row_start, int n_col_start,
             {
                 if(eval_at_end)
                 {
-                    new_row_ind = *remaining_row_ind.end();
+                    new_row_ind = *--remaining_row_ind.end();
                 }
 
                 else


### PR DESCRIPTION
As far as I understand, remaining_row_ind.end() returns an iterator one past
the end of the set. Dereferencing the iterator is thus undefined behaviour.

While the current code (surprisingly) worked on Linux with different versions
of gcc, clang, and icc, the code crashes on Windows when I compile it with
Visual Studio (MSVC).

Therefore, before dereferencing the iterator, the change decrements the
iterator by one to get the last element of the set.

The change seems to fix the problem: The code still works on Linux and no
longer crashes on Windows. I have tested the changes on Linux with my test
suite computing more than 50 determinants.

See also: https://github.com/sivaramambikasaran/HODLR/pull/39