### PR TITLE
Use build/ as build directory instead of bin/

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,8 +47,8 @@ $ sudo apt-get install gcc g++ libc-dev libc++-dev cmake make libopenmpi-dev ope
 will install all dependencies. Here, the dollar sign indicates the shell
 prompt. You can compile the sources with:
 ```
-$ mkdir bin
-$ cd bin
+$ mkdir build
+$ cd build
 $ cmake ..
 $ make
 ```

--- a/docs/manual/manual.rst
+++ b/docs/manual/manual.rst
@@ -119,14 +119,14 @@ These dependencies can be installed with:
     $ sudo apt install gcc g++ libc-dev libc++-dev cmake make libopenmpi-dev openmpi-bin liblapack-dev
 
 
-In order to compile the code, create a directory ``bin`` in the ``caps/``
+In order to compile the code, create a directory ``build`` in the ``caps/``
 directory and run ``cmake`` followed by ``make``:
 
 .. code-block:: none
 
     $ cd caps/
-    $ mkdir bin
-    $ cd bin/
+    $ mkdir build
+    $ cd build/
     $ cmake ..
     $ make
 
@@ -158,7 +158,7 @@ path, is needs to be added to ``LD_LIBRARY_PATH``
 
 .. code-block:: none
 
-    $ export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/home/hendrik/caps/bin
+    $ export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/home/hendrik/caps/build
 
 where we have assumed that the CaPS repository is in the directory
 ``/home/hendrik`` [#hendrik]_ .
@@ -189,8 +189,8 @@ and compile the code using:
 .. code-block:: none
 
     $ cd caps/
-    $ mkdir bin
-    $ cd bin/
+    $ mkdir build
+    $ cd build/
     $ cmake .. -DBLA_VENDOR=ATLAS
     $ make
 
@@ -199,7 +199,7 @@ Testing
 -------
 
 In order to verify that the compilation was successful, build and run
-the unit tests in ``bin/``:
+the unit tests in ``build/``:
 
 .. code-block:: none
 


### PR DESCRIPTION
This PR addresses #148: Instead of using `bin` as build directory, use `build` in `README.md` and in the user manual.