### PR TITLE
Abbreviate Journal of Open Source Software as JOSS

### DIFF
--- a/docs/paper/paper.bib
+++ b/docs/paper/paper.bib
@@ -147,7 +147,7 @@
   volume    = {4},
   number    = {34},
   pages     = {1167},
-  journal   = {J. Open Source Softw.},
+  journal   = {JOSS},
   doi       = {10.21105/joss.01167}
 }
 


### PR DESCRIPTION
Depending on the decision how to abbreviate "Journal of Open Source Software" merge or decline this PR:
 * Abbrevation should be "JOSS" 🡒 merge :heavy_check_mark:
 * Abbrevation should be "J. Open Source Softw." 🡒 decline :x: